### PR TITLE
Fixed unsupported OS query

### DIFF
--- a/customqueries.json
+++ b/customqueries.json
@@ -142,7 +142,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (H:Computer) WHERE H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me)*.' RETURN H"
+                    "query": "MATCH (H:Computer) WHERE H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me).*' RETURN H"
                 }
             ]
         },


### PR DESCRIPTION
Current query will return all results, changed to only match the intended strings. Thanks for sharing these.