### PR TITLE
corrected regex

### DIFF
--- a/customqueries.json
+++ b/customqueries.json
@@ -142,7 +142,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (H:Computer) WHERE H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me)*.' RETURN H"
+                    "query": "MATCH (H:Computer) WHERE H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me).*' RETURN H"
                 }
             ]
         },


### PR DESCRIPTION
the * following . indicates 0-many of any.  The * following the string match (2000|2003|2008|xp|vista|7|me) allows 0-many matches.  Zero matches on the string then causes the regex to be implied as .*  (match anything and nothing).  Consequently as previously written all systems would be returned.  Corrected only those including the string match are returned.