### PR TITLE
fix for query that crashes BloodHound

### DIFF
--- a/customqueries.json
+++ b/customqueries.json
@@ -142,7 +142,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (H:Computer) WHERE H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me).*' RETURN H"
+                    "query": "MATCH (H:Computer) WHERE H.operatingsystem = '.*(2000|2003|2008|xp|vista|7|me).*' RETURN H"
                 }
             ]
         },


### PR DESCRIPTION
in the "Find all computers with unsupported operating systems" query I removed ~

H.operatingsystem =~ '.*(2000|2003|2008|xp|vista|7|me).*'